### PR TITLE
Fix Kvaser dependency linking

### DIFF
--- a/CSharpTest/CSharpTest.csproj
+++ b/CSharpTest/CSharpTest.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Kvaser.KvaDbLib">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Kvaser\Canlib\dotnet\win32\netstandard2.0\Kvaser.KvaDbLib.dll</HintPath>
+      <HintPath>$(ProgramFiles)\Kvaser\Canlib\dotnet\win32\netstandard2.0\Kvaser.KvaDbLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Dependencies
+
+Download and install CANlib SDK: `https://www.kvaser.com/developer/canlib-sdk/`


### PR DESCRIPTION
Relative file paths are used currently, which will break if the project is moved in the directory hierarchy. This patch will change the Kvaser library link to reference ProgramFiles directly to fix this issue.

Also added link to downloading the Kvaser library in a dependency section in README.